### PR TITLE
fixed overcap feature on DRK

### DIFF
--- a/Combos/DRK.cs
+++ b/Combos/DRK.cs
@@ -72,7 +72,7 @@ namespace XIVComboVeryExpandedPlugin.Combos {
 			if (actionID == DRK.StalwartSoul) {
 				if (IsEnabled(CustomComboPreset.DRKOvercapFeature)) {
 					DRKGauge gauge = GetJobGauge<DRKGauge>();
-					if ((gauge.Blood > 70 && SelfHasEffect(DRK.Buffs.BloodWeapon)) || gauge.blood > 80)
+					if ((gauge.Blood > 70 && SelfHasEffect(DRK.Buffs.BloodWeapon)) || gauge.Blood > 80)
 						return DRK.Quietus;
 				}
 

--- a/Combos/DRK.cs
+++ b/Combos/DRK.cs
@@ -72,7 +72,7 @@ namespace XIVComboVeryExpandedPlugin.Combos {
 			if (actionID == DRK.StalwartSoul) {
 				if (IsEnabled(CustomComboPreset.DRKOvercapFeature)) {
 					DRKGauge gauge = GetJobGauge<DRKGauge>();
-					if (gauge.Blood >= 90 && SelfHasEffect(DRK.Buffs.BloodWeapon))
+					if ((gauge.Blood > 70 && SelfHasEffect(DRK.Buffs.BloodWeapon)) || gauge.blood > 80)
 						return DRK.Quietus;
 				}
 


### PR DESCRIPTION
Stalwart soul generates 20 Blood. Overcap will happen if:
1. Blood weapon is up, and we have more than 70 gauge
2. We have more than 80 gauge