### PR TITLE
Always prefer Acceleration over Swiftcast

### DIFF
--- a/Combos/RDM.cs
+++ b/Combos/RDM.cs
@@ -5,6 +5,8 @@ using System;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Types;
 
+using global::XIVComboVX.GameData;
+
 internal static class RDM {
 	public const byte JobID = 35;
 
@@ -467,11 +469,12 @@ internal class RedMageAcceleration: CustomCombo {
 	protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) {
 
 		if (level >= RDM.Levels.Acceleration) {
+			CooldownData acceleration = GetCooldown(RDM.Acceleration);
 
-			if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption) && IsOffCooldown(RDM.Acceleration) && IsOffCooldown(RDM.Swiftcast))
+			if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption) && acceleration.RemainingCharges == 0 && IsOffCooldown(RDM.Swiftcast))
 				return RDM.Swiftcast;
 
-			if (IsOffCooldown(RDM.Acceleration))
+			if (acceleration.RemainingCharges > 0)
 				return RDM.Acceleration;
 
 			if (IsOffCooldown(RDM.Swiftcast))

--- a/Combos/RDM.cs
+++ b/Combos/RDM.cs
@@ -5,8 +5,6 @@ using System;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Types;
 
-using global::XIVComboVX.GameData;
-
 internal static class RDM {
 	public const byte JobID = 35;
 
@@ -469,15 +467,16 @@ internal class RedMageAcceleration: CustomCombo {
 	protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) {
 
 		if (level >= RDM.Levels.Acceleration) {
-			CooldownData acceleration = GetCooldown(RDM.Acceleration);
+			bool canAccelerate = HasCharges(RDM.Acceleration);
+			bool canSwiftcast = HasCharges(RDM.Swiftcast);
 
-			if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption) && acceleration.RemainingCharges > 0 && IsOffCooldown(RDM.Swiftcast))
+			if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption) && canAccelerate && canSwiftcast)
 				return RDM.Swiftcast;
 
-			if (acceleration.RemainingCharges > 0)
+			if (canAccelerate)
 				return RDM.Acceleration;
 
-			if (IsOffCooldown(RDM.Swiftcast))
+			if (canSwiftcast)
 				return RDM.Swiftcast;
 
 			return RDM.Acceleration;

--- a/Combos/RDM.cs
+++ b/Combos/RDM.cs
@@ -471,7 +471,7 @@ internal class RedMageAcceleration: CustomCombo {
 		if (level >= RDM.Levels.Acceleration) {
 			CooldownData acceleration = GetCooldown(RDM.Acceleration);
 
-			if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption) && acceleration.RemainingCharges == 0 && IsOffCooldown(RDM.Swiftcast))
+			if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption) && acceleration.RemainingCharges > 0 && IsOffCooldown(RDM.Swiftcast))
 				return RDM.Swiftcast;
 
 			if (acceleration.RemainingCharges > 0)


### PR DESCRIPTION
Acceleration has two charges, but if you used it once, it was considered to be off cooldown, despite the remaining charge. Checking for remaining charges instead ensures that Acceleration displayed instead of Swiftcast as long as it has at least one charge, when Swiftcast is not prioritised.