### PR TITLE
Ensure that player health calculations are correct

### DIFF
--- a/CustomCombo.cs
+++ b/CustomCombo.cs
@@ -225,7 +225,7 @@ internal abstract class CustomCombo {
 		=> Service.BuddyList.PetBuddyPresent;
 
 	protected static double PlayerHealthPercentage
-		=> LocalPlayer.CurrentHp / LocalPlayer.MaxHp * 100;
+		=> (Convert.ToDouble(LocalPlayer.CurrentHp) / Convert.ToDouble(LocalPlayer.MaxHp)) * 100.0;
 
 	protected internal static bool ShouldSwiftcast
 		=> IsOffCooldown(Common.Swiftcast)


### PR DESCRIPTION
I noticed that with one of the monk features enabled I was using bloodbath all the time. I think it's because this returns either 100 on full health, or 0 when your health isn't full. I'm not a C# expert, so open to better solutions, but this seemed to fix it.