### PR TITLE
Add DOT refresh feature to White Mage combos

### DIFF
--- a/XIVComboVX/Combos/WHM.cs
+++ b/XIVComboVX/Combos/WHM.cs
@@ -1,11 +1,13 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.Text;
 
 namespace PrincessRTFM.XIVComboVX.Combos;
 
 internal static class WHM {
 	public const byte JobID = 24;
 
-	public const uint Stone = 119,
+	public const uint 
+		Stone = 119,
 		Cure = 120,
 		Aero = 121,
 		Medica = 124,
@@ -38,15 +40,14 @@ internal static class WHM {
 	}
 
 	public static class Debuffs {
-		public const ushort Aero = 143, //Aero
-			Aero2 = 144, //Aero II
-			Dia = 1871; //Dia
+		public const ushort 
+			Aero = 143,
+			Aero2 = 144,
+			Dia = 1871;
 	}
 
 	public static class Levels {
-		public const byte Aero = 4,
-			Aero2 = 46,
-			Dia = 72,
+		public const byte 
 			Cure2 = 30,
 			AfflatusSolace = 52,
 			AfflatusMisery = 74,
@@ -82,20 +83,15 @@ internal class WhiteMageStone: CustomCombo {
 		
 		if (IsEnabled(CustomComboPreset.WhiteMageDotRefresh))
 		{
-			uint dotForLevel = level switch {
-				>= WHM.Levels.Dia => WHM.Dia,
-				>= WHM.Levels.Aero2 => WHM.Aero2,
-				>= WHM.Levels.Aero => WHM.Aero,
-			};
-			ushort effectId = dotForLevel switch
+			ushort effectIdToTrack = OriginalHook(WHM.Aero) switch
 			{
 				WHM.Aero => WHM.Debuffs.Aero,
 				WHM.Aero2 => WHM.Debuffs.Aero2,
 				WHM.Dia => WHM.Debuffs.Dia,
 			};
-
-			if (HasTarget && TargetOwnEffectDuration(effectId) < Service.Configuration.WhiteMageDotRefreshDuration)
-				return dotForLevel;
+			
+			if (HasTarget && TargetOwnEffectDuration(effectIdToTrack) < Service.Configuration.WhiteMageDotRefreshDuration)
+				return OriginalHook(WHM.Aero);
 		}
 
 		return actionID;

--- a/XIVComboVX/Combos/WHM.cs
+++ b/XIVComboVX/Combos/WHM.cs
@@ -5,8 +5,7 @@ namespace PrincessRTFM.XIVComboVX.Combos;
 internal static class WHM {
 	public const byte JobID = 24;
 
-	public const uint
-		Stone = 119,
+	public const uint Stone = 119,
 		Cure = 120,
 		Aero = 121,
 		Medica = 124,
@@ -39,11 +38,15 @@ internal static class WHM {
 	}
 
 	public static class Debuffs {
-		// public const ushort placeholder = 0;
+		public const ushort Aero = 143, //Aero
+			Aero2 = 144, //Aero II
+			Dia = 1871; //Dia
 	}
 
 	public static class Levels {
-		public const byte
+		public const byte Aero = 4,
+			Aero2 = 46,
+			Dia = 72,
 			Cure2 = 30,
 			AfflatusSolace = 52,
 			AfflatusMisery = 74,
@@ -76,6 +79,24 @@ internal class WhiteMageStone: CustomCombo {
 
 		if (Common.CheckLucidWeave(CustomComboPreset.WhiteMageLucidWeave, level, Service.Configuration.WhiteMageLucidWeaveManaThreshold, actionID))
 			return Common.LucidDreaming;
+		
+		if (IsEnabled(CustomComboPreset.WhiteMageDotRefresh))
+		{
+			uint dotForLevel = level switch {
+				>= WHM.Levels.Dia => WHM.Dia,
+				>= WHM.Levels.Aero2 => WHM.Aero2,
+				>= WHM.Levels.Aero => WHM.Aero,
+			};
+			ushort effectId = dotForLevel switch
+			{
+				WHM.Aero => WHM.Debuffs.Aero,
+				WHM.Aero2 => WHM.Debuffs.Aero2,
+				WHM.Dia => WHM.Debuffs.Dia,
+			};
+
+			if (HasTarget && TargetOwnEffectDuration(effectId) < Service.Configuration.WhiteMageDotRefreshDuration)
+				return dotForLevel;
+		}
 
 		return actionID;
 	}

--- a/XIVComboVX/Combos/WHM.cs
+++ b/XIVComboVX/Combos/WHM.cs
@@ -81,10 +81,8 @@ internal class WhiteMageStone: CustomCombo {
 		if (Common.CheckLucidWeave(CustomComboPreset.WhiteMageLucidWeave, level, Service.Configuration.WhiteMageLucidWeaveManaThreshold, actionID))
 			return Common.LucidDreaming;
 		
-		if (IsEnabled(CustomComboPreset.WhiteMageDotRefresh))
-		{
-			ushort effectIdToTrack = OriginalHook(WHM.Aero) switch
-			{
+		if (IsEnabled(CustomComboPreset.WhiteMageDotRefresh)){
+			ushort effectIdToTrack = OriginalHook(WHM.Aero) switch {
 				WHM.Aero => WHM.Debuffs.Aero,
 				WHM.Aero2 => WHM.Debuffs.Aero2,
 				WHM.Dia => WHM.Debuffs.Dia,

--- a/XIVComboVX/Combos/WHM.cs
+++ b/XIVComboVX/Combos/WHM.cs
@@ -6,7 +6,7 @@ namespace PrincessRTFM.XIVComboVX.Combos;
 internal static class WHM {
 	public const byte JobID = 24;
 
-	public const uint 
+	public const uint
 		Stone = 119,
 		Cure = 120,
 		Aero = 121,
@@ -47,7 +47,7 @@ internal static class WHM {
 	}
 
 	public static class Levels {
-		public const byte 
+		public const byte
 			Cure2 = 30,
 			AfflatusSolace = 52,
 			AfflatusMisery = 74,

--- a/XIVComboVX/Config/PluginConfiguration.cs
+++ b/XIVComboVX/Config/PluginConfiguration.cs
@@ -412,6 +412,15 @@ public class PluginConfiguration: IPluginConfiguration {
 
 	[LucidWeavingSetting(CustomComboPreset.WhiteMageLucidWeave)]
 	public uint WhiteMageLucidWeaveManaThreshold { get; set; } = 7000;
+	
+	[ComboDetailSetting(
+		CustomComboPreset.WhiteMageDotRefresh,
+		"Debuff time threshold",
+		"When your current target's debuff only has this many seconds left, switch back to DOT",
+		0,
+		30
+	)]
+	public float WhiteMageDotRefreshDuration { get; set; } = 3F;
 
 	#endregion
 

--- a/XIVComboVX/Config/PluginConfiguration.cs
+++ b/XIVComboVX/Config/PluginConfiguration.cs
@@ -416,7 +416,7 @@ public class PluginConfiguration: IPluginConfiguration {
 	[ComboDetailSetting(
 		CustomComboPreset.WhiteMageDotRefresh,
 		"Debuff time threshold",
-		"When your current target's debuff only has this many seconds left, switch back to DOT",
+		"When your current target's Aero/Aero2/Dia debuff only has this many seconds left, switch back to DOT",
 		0,
 		30
 	)]

--- a/XIVComboVX/CustomComboPreset.cs
+++ b/XIVComboVX/CustomComboPreset.cs
@@ -1490,6 +1490,9 @@ public enum CustomComboPreset {
 
 	[CustomComboInfo("Cure 2 Level Sync", "Changes Cure 2 to Cure when below level 30 in synced content.", WHM.JobID)]
 	WhiteMageCureFeature = 2403,
+	
+	[CustomComboInfo("DOT Refresh", "Replace Stone/Glare with level appropriate DOT when debuff is about to fall off.", WHM.JobID)]
+	WhiteMageDotRefresh = 2407,
 
 	#endregion
 	// ====================================================================================


### PR DESCRIPTION
Add new DOT refresh combo; replaces Stone/Glare with a level-appropriate DOT when the debuff is nearing a configurable time to expire