### PR TITLE
Reinstate several SAM combos

### DIFF
--- a/XIVComboVX/Combos/SAM.cs
+++ b/XIVComboVX/Combos/SAM.cs
@@ -1,3 +1,6 @@
+using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Types;
+
 namespace PrincessRTFM.XIVComboVX.Combos;
 
 internal static class SAM {
@@ -27,7 +30,6 @@ internal static class SAM {
 		HissatsuSenei = 16481,
 		HissatsuGuren = 7496,
 		Ikishoten = 16482,
-		Shoha2 = 25779,
 		OgiNamikiri = 25781,
 		KaeshiNamikiri = 25782,
 		Gyofu = 36963,
@@ -62,7 +64,6 @@ internal static class SAM {
 			HissatsuSenei = 72,
 			TsubameGaeshi = 76,
 			Shoha = 80,
-			Shoha2 = 82,
 			Hyosetsu = 86,
 			Fuko = 86,
 			KaeshiNamikiri = 90,
@@ -78,15 +79,7 @@ internal static class SAM {
 internal class SamuraiBloodbathReplacer: SecondBloodbathCombo {
 	public override CustomComboPreset Preset => CustomComboPreset.SamuraiBloodbathReplacer;
 }
-/*
-internal class SamuraiGurenSeneiLevelSyncFeature: CustomCombo {
-	public override CustomComboPreset Preset { get; } = CustomComboPreset.SamuraiGurenSeneiLevelSyncFeature;
-	public override uint[] ActionIDs { get; } = [SAM.HissatsuSenei];
 
-	protected override uint Invoke(uint actionID, uint lastComboActionId, float comboTime, byte level)
-		=> level >= SAM.Levels.HissatsuSenei ? SAM.HissatsuSenei : SAM.HissatsuGuren;
-}
-*/
 internal class SamuraiYukikazeCombo: CustomCombo {
 	public override CustomComboPreset Preset => CustomComboPreset.SamuraiYukikazeCombo;
 	public override uint[] ActionIDs { get; } = [SAM.Yukikaze];
@@ -181,7 +174,7 @@ internal class SamuraiOkaCombo: CustomCombo {
 		return OriginalHook(SAM.Fuga);
 	}
 }
-/*
+
  internal class SamuraiTsubameGaeshiFeature: CustomCombo {
 	public override CustomComboPreset Preset => CustomComboPreset.SamAny;
 	public override uint[] ActionIDs { get; } = [SAM.TsubameGaeshi];
@@ -239,7 +232,7 @@ internal class SamuraiShinten: CustomCombo {
 				return SAM.HissatsuSenei;
 			}
 
-			if (IsEnabled(CustomComboPreset.SamuraiSeneiGurenFeature)) {
+			if (IsEnabled(CustomComboPreset.SamuraiGurenSeneiLevelSyncFeature)) {
 				if (level is >= SAM.Levels.HissatsuGuren and < SAM.Levels.HissatsuSenei && IsOffCooldown(SAM.HissatsuGuren))
 					return SAM.HissatsuGuren;
 			}
@@ -256,7 +249,7 @@ internal class SamuraiSenei: CustomCombo {
 
 	protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) {
 
-		if (IsEnabled(CustomComboPreset.SamuraiSeneiGurenFeature)) {
+		if (IsEnabled(CustomComboPreset.SamuraiGurenSeneiLevelSyncFeature)) {
 			if (level is >= SAM.Levels.HissatsuGuren and < SAM.Levels.HissatsuSenei)
 				return SAM.HissatsuGuren;
 		}
@@ -271,8 +264,8 @@ internal class SamuraiKyuten: CustomCombo {
 
 	protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) {
 
-		if (IsEnabled(CustomComboPreset.SamuraiKyutenShoha2Feature) && level >= SAM.Levels.Shoha2 && GetJobGauge<SAMGauge>().MeditationStacks >= 3)
-			return SAM.Shoha2;
+		if (IsEnabled(CustomComboPreset.SamuraiKyutenShohaFeature) && level >= SAM.Levels.Shoha && GetJobGauge<SAMGauge>().MeditationStacks >= 3)
+			return SAM.Shoha;
 
 		if (IsEnabled(CustomComboPreset.SamuraiKyutenGurenFeature)
 			&& level >= SAM.Levels.HissatsuGuren
@@ -308,4 +301,4 @@ internal class SamuraiIkishotenNamikiriFeature: CustomCombo {
 		return actionID;
 	}
 }
-*/
+

--- a/XIVComboVX/CustomComboPreset.cs
+++ b/XIVComboVX/CustomComboPreset.cs
@@ -1176,42 +1176,39 @@ public enum CustomComboPreset {
 	[CustomComboInfo("Oka Combo", "Replace Oka with its combo chain.", SAM.JobID)]
 	SamuraiOkaCombo = 3404,
 
-	//[Conflicts(SamuraiIaijutsuTsubameGaeshiFeature)]
-	//[CustomComboInfo("Tsubame-gaeshi to Iaijutsu", "Replace Tsubame-gaeshi with Iaijutsu when Sen is empty.", SAM.JobID)]
-	//SamuraiTsubameGaeshiIaijutsuFeature = 3407,
+	[Conflicts(SamuraiIaijutsuTsubameGaeshiFeature)]
+	[CustomComboInfo("Tsubame-gaeshi to Iaijutsu", "Replace Tsubame-gaeshi with Iaijutsu when Sen is not empty.", SAM.JobID)]
+	SamuraiTsubameGaeshiIaijutsuFeature = 3407,
 
-	//[Conflicts(SamuraiIaijutsuShohaFeature)]
-	//[CustomComboInfo("Tsubame-gaeshi to Shoha", "Replace Tsubame-gaeshi with Shoha when meditation is 3.", SAM.JobID)]
-	//SamuraiTsubameGaeshiShohaFeature = 3409,
+	[Conflicts(SamuraiIaijutsuShohaFeature)]
+	[CustomComboInfo("Tsubame-gaeshi to Shoha", "Replace Tsubame-gaeshi with Shoha when meditation is 3.", SAM.JobID)]
+	SamuraiTsubameGaeshiShohaFeature = 3409,
 
-	//[Conflicts(SamuraiTsubameGaeshiIaijutsuFeature)]
-	//[CustomComboInfo("Iaijutsu to Tsubame-gaeshi", "Replace Iaijutsu with Tsubame-gaeshi when Sen is not empty.", SAM.JobID)]
-	//SamuraiIaijutsuTsubameGaeshiFeature = 3408,
+	[Conflicts(SamuraiTsubameGaeshiIaijutsuFeature)]
+	[CustomComboInfo("Iaijutsu to Tsubame-gaeshi", "Replace Iaijutsu with Tsubame-gaeshi when Sen is empty.", SAM.JobID)]
+	SamuraiIaijutsuTsubameGaeshiFeature = 3408,
 
-	//[Conflicts(SamuraiTsubameGaeshiShohaFeature)]
-	//[CustomComboInfo("Iaijutsu to Shoha", "Replace Iaijutsu with Shoha when meditation is 3.", SAM.JobID)]
-	//SamuraiIaijutsuShohaFeature = 3410,
+	[Conflicts(SamuraiTsubameGaeshiShohaFeature)]
+	[CustomComboInfo("Iaijutsu to Shoha", "Replace Iaijutsu with Shoha when meditation is 3.", SAM.JobID)]
+	SamuraiIaijutsuShohaFeature = 3410,
 
-	//[CustomComboInfo("Shinten to Senei", "Replace Hissatsu: Shinten with Senei when available.", SAM.JobID)]
-	//SamuraiShintenSeneiFeature = 3414,
+	[CustomComboInfo("Shinten to Senei", "Replace Hissatsu: Shinten with Senei when available.", SAM.JobID)]
+	SamuraiShintenSeneiFeature = 3414,
 
-	//[CustomComboInfo("Senei to Guren Level Sync", "Replace Hissatsu: Senei with Guren when level synced below 72.", SAM.JobID)]
-	//SamuraiSeneiGurenFeature = 3419,
+	[CustomComboInfo("Shinten to Shoha", "Replace Hissatsu: Shinten with Shoha when Meditation is full.", SAM.JobID)]
+	SamuraiShintenShohaFeature = 3413,
 
-	//[CustomComboInfo("Shinten to Shoha", "Replace Hissatsu: Shinten with Shoha when Meditation is full.", SAM.JobID)]
-	//SamuraiShintenShohaFeature = 3413,
+	[CustomComboInfo("Kyuten to Guren", "Replace Hissatsu: Kyuten with Guren when available.", SAM.JobID)]
+	SamuraiKyutenGurenFeature = 3415,
 
-	//[CustomComboInfo("Kyuten to Guren", "Replace Hissatsu: Kyuten with Guren when available.", SAM.JobID)]
-	//SamuraiKyutenGurenFeature = 3415,
+	[CustomComboInfo("Kyuten to Shoha", "Replace Hissatsu: Kyuten with Shoha when Meditation is full.", SAM.JobID)]
+	SamuraiKyutenShohaFeature = 3412,
 
-	//[CustomComboInfo("Kyuten to Shoha 2", "Replace Hissatsu: Kyuten with Shoha 2 when Meditation is full.", SAM.JobID)]
-	//SamuraiKyutenShoha2Feature = 3412,
+	[CustomComboInfo("Ikishoten Namikiri Feature", "Replace Ikishoten with Shoha, Kaeshi Namikiri, and then Ogi Namikiri when available.", SAM.JobID)]
+	SamuraiIkishotenNamikiriFeature = 3411,
 
-	//[CustomComboInfo("Ikishoten Namikiri Feature", "Replace Ikishoten with Shoha, Kaeshi Namikiri, and then Ogi Namikiri when available.", SAM.JobID)]
-	//SamuraiIkishotenNamikiriFeature = 3411,
-
-	//[CustomComboInfo("Hissatsu Senei/Guren Sync Feature", "Replace Hissatsu Senei with Hissatsu Guren when underlevel.", SAM.JobID)]
-	//SamuraiGurenSeneiLevelSyncFeature = 3418,
+	[CustomComboInfo("Hissatsu Senei/Guren Sync Feature", "Replace Hissatsu Senei with Hissatsu Guren when underlevel.", SAM.JobID)]
+	SamuraiGurenSeneiLevelSyncFeature = 3418,
 
 	#endregion
 	// ====================================================================================


### PR DESCRIPTION
Re-enable existing SAM combos. Most were unchanged except the following:

1. `SamuraiSeneiGurenFeature` enum was removed because it has the same functionality as `SamuraiGurenSeneiLevelSyncFeature` and the former had an ID conflict while the latter did not. Similarly, `SamuraiGurenSeneiLevelSyncFeature` combo was also removed as it also duplicated the functionality of `SamuraiSenei` combo. Enabling `SamuraiGurenSeneiLevelSyncFeature` now performs level sync logic in both `SamuraiShinten` and `SamuraiSenei` combos.
2. `SamuraiKyutenShoha2Feature` is now `SamuraiKyutenShohaFeature` as the skills have been merged.
3. The sen empty/not empty wording for `SamuraiTsubameGaeshiIaijutsuFeature` and `SamuraiIaijutsuTsubameGaeshiFeature` was backwards and has been fixed.

This doesn't add support for any new skills.