### PR TITLE
Update for 7.2 compatibility

### DIFF
--- a/XIVComboVX/Combos/BRD.cs
+++ b/XIVComboVX/Combos/BRD.cs
@@ -85,7 +85,7 @@ internal class BardHeavyBurstShot: CustomCombo {
 			if (IsEnabled(CustomComboPreset.BardWeavePitchPerfect) && level >= BRD.Levels.PitchPerfect) {
 				BRDGauge gauge = GetJobGauge<BRDGauge>();
 
-				if (gauge.Song is Song.WANDERER && gauge.Repertoire > 0) {
+				if (gauge.Song is Song.Wanderer && gauge.Repertoire > 0) {
 					Status? minuet = SelfFindEffect(BRD.Buffs.WanderersMinuet);
 
 					if (gauge.SongTimer / 1000f <= Service.Configuration.BardWanderersMinuetBuffThreshold)

--- a/XIVComboVX/Combos/SAM.cs
+++ b/XIVComboVX/Combos/SAM.cs
@@ -186,7 +186,7 @@ internal class SamuraiOkaCombo: CustomCombo {
 			return SAM.Shoha;
 
 		if (IsEnabled(CustomComboPreset.SamuraiTsubameGaeshiIaijutsuFeature)) {
-			if (level >= SAM.Levels.TsubameGaeshi && gauge.Sen == Sen.NONE)
+			if (level >= SAM.Levels.TsubameGaeshi && gauge.Sen == Sen.None)
 				return OriginalHook(SAM.TsubameGaeshi);
 
 			return OriginalHook(SAM.Iaijutsu);
@@ -207,7 +207,7 @@ internal class SamuraiIaijutsuFeature: CustomCombo {
 			return SAM.Shoha;
 
 		if (IsEnabled(CustomComboPreset.SamuraiIaijutsuTsubameGaeshiFeature)) {
-			if (level >= SAM.Levels.TsubameGaeshi && gauge.Sen == Sen.NONE)
+			if (level >= SAM.Levels.TsubameGaeshi && gauge.Sen == Sen.None)
 				return OriginalHook(SAM.TsubameGaeshi);
 
 			return OriginalHook(SAM.Iaijutsu);
@@ -291,7 +291,7 @@ internal class SamuraiIkishotenNamikiriFeature: CustomCombo {
 			if (level >= SAM.Levels.Shoha && gauge.MeditationStacks >= 3)
 				return SAM.Shoha;
 
-			if (gauge.Kaeshi == Kaeshi.NAMIKIRI)
+			if (gauge.Kaeshi == Kaeshi.Namikiri)
 				return SAM.KaeshiNamikiri;
 
 			if (SelfHasEffect(SAM.Buffs.OgiNamikiriReady))

--- a/XIVComboVX/CustomCombo.cs
+++ b/XIVComboVX/CustomCombo.cs
@@ -209,7 +209,7 @@ internal abstract class CustomCombo {
 		=> Service.DataCache.GetJobGauge<T>();
 
 	protected internal static unsafe bool IsMoving
-		=> AgentMap.Instance() is not null && AgentMap.Instance()->IsPlayerMoving > 0;
+		=> AgentMap.Instance() is not null && AgentMap.Instance()->IsPlayerMoving;
 
 	#endregion
 
@@ -274,7 +274,7 @@ internal abstract class CustomCombo {
 	protected internal static float SelfEffectDuration(ushort effectId)
 		=> SelfFindEffect(effectId)?.RemainingTime ?? 0;
 	protected internal static float SelfEffectStacks(ushort effectId)
-		=> SelfFindEffect(effectId)?.StackCount ?? 0;
+		=> SelfFindEffect(effectId)?.Param ?? 0;
 
 	protected internal static Status? TargetFindAnyEffect(ushort effectId)
 		=> FindEffect(effectId, CurrentTarget, null);
@@ -283,7 +283,7 @@ internal abstract class CustomCombo {
 	protected internal static float TargetAnyEffectDuration(ushort effectId)
 		=> TargetFindAnyEffect(effectId)?.RemainingTime ?? 0;
 	protected internal static float TargetAnyEffectStacks(ushort effectId)
-		=> TargetFindAnyEffect(effectId)?.StackCount ?? 0;
+		=> TargetFindAnyEffect(effectId)?.Param ?? 0;
 
 	protected internal static Status? TargetFindOwnEffect(ushort effectId)
 		=> FindEffect(effectId, CurrentTarget, LocalPlayer?.EntityId);
@@ -292,7 +292,7 @@ internal abstract class CustomCombo {
 	protected internal static float TargetOwnEffectDuration(ushort effectId)
 		=> TargetFindOwnEffect(effectId)?.RemainingTime ?? 0;
 	protected internal static float TargetOwnEffectStacks(ushort effectId)
-		=> TargetFindOwnEffect(effectId)?.StackCount ?? 0;
+		=> TargetFindOwnEffect(effectId)?.Param ?? 0;
 
 	protected internal static Status? FindEffect(ushort effectId, IGameObject? actor, uint? sourceId)
 		=> Service.DataCache.GetStatus(effectId, actor, sourceId);

--- a/XIVComboVX/XIVComboVX.csproj
+++ b/XIVComboVX/XIVComboVX.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<Product>XIVComboVX</Product>
 		<Authors>VariableVixen, FrigidWalrus, attick, daemitus</Authors>
-		<Version>9.31.0</Version>
+		<Version>9.32.0</Version>
 		<Description>This plugin condenses various abilities onto single buttons.</Description>
 		<PackageProjectUrl>https://github.com/PrincessRTFM/XIVComboPlugin</PackageProjectUrl>
 		<Copyright>Copyleft attick 2020 baybeeee</Copyright>

--- a/XIVComboVX/dalamud.props
+++ b/XIVComboVX/dalamud.props
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<Platforms>x64</Platforms>
 		<PlatformTarget>x64</PlatformTarget>
-		<TargetFramework>net8-windows</TargetFramework>
+		<TargetFramework>net9-windows</TargetFramework>
 		<OutputType>Library</OutputType>
 		<Deterministic>false</Deterministic>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -15,7 +15,7 @@
 	<Import Project="framework.props" />
 
 	<ItemGroup>
-		<PackageReference Include="DalamudPackager" Version="11.0.0" />
+		<PackageReference Include="DalamudPackager" Version="12.0.0" />
 		<Reference Include="Newtonsoft.Json">
 			<HintPath>$(DalamudLibPath)Newtonsoft.Json.dll</HintPath>
 			<Private>False</Private>

--- a/XIVComboVX/packages.lock.json
+++ b/XIVComboVX/packages.lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net9.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[11.0.0, )",
-        "resolved": "11.0.0",
-        "contentHash": "bjT7XUlhIJSmsE/O76b7weUX+evvGQctbQB8aKXt94o+oPWxHpCepxAGMs7Thow3AzCyqWs7cOpp9/2wcgRRQA=="
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "J5TJLV3f16T/E2H2P17ClWjtfEBPpq3yxvqW46eN36JCm6wR+EaoaYkqG9Rm5sHqs3/nK/vKjWWyvEs/jhKoXw=="
       }
     }
   }


### PR DESCRIPTION
This is a quick compatibility update for 7.2. Compiles fine and seems to run fine after a few tests.

Changing

```
protected internal static unsafe bool IsMoving
    => AgentMap.Instance() is not null && AgentMap.Instance()->IsPlayerMoving > 0;
```

to

```
protected internal static unsafe bool IsMoving
    => AgentMap.Instance() is not null && AgentMap.Instance()->IsPlayerMoving;
```

seems to cause no problems and was suggested by plugin devs on the Dalamud Discord. If it should cause problems, then changing the > 0 to == true should do the trick.

EDIT:

Added a version bump to the PR.